### PR TITLE
Fix missing uid when uid is integer

### DIFF
--- a/src/lib/piwik.js
+++ b/src/lib/piwik.js
@@ -11,7 +11,7 @@ export default function piwik (method, ...args) {
   const tracker = client.getTracker(piwikEndpoint, piwikSiteId);
 
   if ( userId != null ){
-    tracker.setUserId(userId);
+    tracker.setUserId(userId.toString());
   }
 
   if(method === 'pageview'){


### PR DESCRIPTION
Fix the missing `uid` while the uid is integer